### PR TITLE
Make pkg parameter to Wsdl case class optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ Any WSDLs added to the `cxfWsdls` setting are automatically picked up. For examp
         id = "mywsdl",
         wsdlFile = (resourceDirectory in Compile).value / "wsdl" / "my-wsdl.wsdl",
         implementations = Seq(CxfImplementationType.Impl, CxfImplementationType.Client),
-        pkg = "com.acme.generated.jaxws.my",
+        pkg = Some("com.acme.generated.jaxws.my"),
         bindFile = Some((resourceDirectory in Compile).value / "wsdl" / "my-wsdl-bindings.xjb")
       ),
       Wsdl(
         id = "otherwsdl",
         wsdlFile = (resourceDirectory in Compile).value / "wsdl" / "other.wsdl",
         implementations = Seq(CxfImplementationType.Impl, CxfImplementationType.Client),
-        pkg = "com.acme.generated.jaxws.other"
+        pkg = Some("com.acme.generated.jaxws.other")
       )
     )
   )

--- a/src/main/scala/io/dapas/sbt/cxf/CxfPlugin.scala
+++ b/src/main/scala/io/dapas/sbt/cxf/CxfPlugin.scala
@@ -37,7 +37,14 @@ object CxfPlugin extends sbt.AutoPlugin {
       val Client, Impl, Server = Value
     }
 
-    case class Wsdl(id: String, wsdlFile: File, pkg: String, implementations: Seq[CxfImplementationType.Value] = Seq(CxfImplementationType.Client, CxfImplementationType.Impl), extraFlags: Seq[String] = Nil, bindFile: Option[File] = None)
+    case class Wsdl(
+      id: String, 
+      wsdlFile: File, 
+      pkg: Option[String] = None, 
+      implementations: Seq[CxfImplementationType.Value] = Seq(CxfImplementationType.Client, CxfImplementationType.Impl), 
+      extraFlags: Seq[String] = Nil, 
+      bindFile: Option[File] = None
+    )
 
   }
 
@@ -82,7 +89,7 @@ object CxfPlugin extends sbt.AutoPlugin {
 
       def params(wsdl: Wsdl): Seq[String] =
         cxfFlags.value ++
-          Seq("-p", wsdl.pkg) ++
+          wsdl.pkg.fold[Seq[String]](Seq.empty)(pkg => Seq("-p", pkg)) ++
           wsdl.implementations.map {
             case CxfImplementationType.Client => "-client"
             case CxfImplementationType.Impl => "-impl"

--- a/src/sbt-test/sbt-cxf/alt-target/build.sbt
+++ b/src/sbt-test/sbt-cxf/alt-target/build.sbt
@@ -7,7 +7,7 @@ lazy val root = (project in file("."))
         id = "simple",
         wsdlFile = (resourceDirectory in Compile).value / "wsdl" / "simple.wsdl",
         implementations = Seq(CxfImplementationType.Impl),
-        pkg = "acme.simple"
+        pkg = Some("acme.simple")
       )
     ),
     cxfTarget := (crossTarget in Compile).value / "cxf"

--- a/src/sbt-test/sbt-cxf/alt-version/build.sbt
+++ b/src/sbt-test/sbt-cxf/alt-version/build.sbt
@@ -11,7 +11,7 @@ lazy val root = (project in file("."))
         id = "simple",
         wsdlFile = (resourceDirectory in Compile).value / "wsdl" / "simple.wsdl",
         implementations = Seq(CxfImplementationType.Impl),
-        pkg = "acme.simple"
+        pkg = Some("acme.simple")
       )
     ),
     cxfVersion := "3.2.0",

--- a/src/sbt-test/sbt-cxf/impl-full/build.sbt
+++ b/src/sbt-test/sbt-cxf/impl-full/build.sbt
@@ -7,7 +7,7 @@ lazy val root = (project in file("."))
         id = "simple",
         wsdlFile = (resourceDirectory in Compile).value / "wsdl" / "simple.wsdl",
         implementations = Seq(CxfImplementationType.Impl, CxfImplementationType.Client, CxfImplementationType.Server),
-        pkg = "acme.simple"
+        pkg = Some("acme.simple")
       )
     )
   )

--- a/src/sbt-test/sbt-cxf/simple/build.sbt
+++ b/src/sbt-test/sbt-cxf/simple/build.sbt
@@ -7,7 +7,7 @@ lazy val root = (project in file("."))
         id = "simple",
         wsdlFile = (resourceDirectory in Compile).value / "wsdl" / "simple.wsdl",
         implementations = Seq(CxfImplementationType.Impl),
-        pkg = "acme.simple"
+        pkg = Some("acme.simple")
       )
     )
   )


### PR DESCRIPTION
The package parameter is not necessary for the wsdl2java cli tool, and in some cases it is harmful to have to specify it, especially if the WSDL is composed of many schemas which may have overlapping elements. In this case it is better to omit the package parameter, this emits the classes into packages according their schema names. That ensures that there are no conflicts.

Fixes #6 